### PR TITLE
Add support for mix target

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plug 'amiralies/coc-elixir', {'do': 'yarn install && yarn prepack'}
 - Smart closing of code blocks
 - Code formatter
 
-## Dialayzer integration
+## Dialyzer integration
 Coc-elixir will automatically analyze your project with [Dialyzer](http://erlang.org/doc/apps/dialyzer/dialyzer_chapter.html) after each successful build. It maintains a "manifest" file in `.elixir_ls/dialyzer_manifest` that stores the results of the analysis.
 
 You can control which warnings are shown using the `elixirLS.dialyzerWarnOpts` setting in `coc-setting.json`, found at `~/.config/nvim/coc-settings.json`, or use command `:CocConfig` to open configuration file.
@@ -45,6 +45,18 @@ To disable Dialyzer completely add setting:
 }
 ```
 You can also set the module attribute @dialyzer to show or hide warnings at a module or function level.
+
+## Mix environment and target settings
+
+You can control the settings that ElixirLS uses for Mix environment and target using either the user `coc-settings.json` or a [workspace configuration](https://github.com/neoclide/coc.nvim/wiki/Using-the-configuration-file#configuration-file-resolve).
+
+To change the Mix environment and target, add the settings:
+```json
+{
+  "elixirLS.mixEnv": "dev",
+  "elixirLS.mixTarget": "test"
+}
+```
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,12 @@
           "default": "test",
           "minLength": 1
         },
+        "elixirLS.mixTarget": {
+          "type": "string",
+          "description": "Mix target to use for compilation",
+          "default": "host",
+          "minLength": 1
+        },
         "elixirLS.projectDir": {
           "type": "string",
           "description": "Subdirectory containing Mix project if not in the project root",

--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
           "minLength": 1
         },
         "elixirLS.mixTarget": {
+          "scope": "resource",
           "type": "string",
-          "description": "Mix target to use for compilation",
-          "default": "host",
-          "minLength": 1
+          "description": "Mix target to use for compilation (requires Elixir >= 1.8)",
+          "minLength": 0
         },
         "elixirLS.projectDir": {
           "type": "string",


### PR DESCRIPTION
Adds support for [mix target](https://hexdocs.pm/mix/Mix.html#module-targets) which is useful when developing for Nerves.